### PR TITLE
Update To NumPy 2.0 And SciPy 1.12

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,7 +32,6 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install -e .
-          pip install numpy==1.26.4
           pip install pytest
 
       - name: Run unit/benchmark tests

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,18 +13,19 @@ on:
 
 jobs:
   test:
-    runs-on: macos-latest
+    runs-on: ${{ matrix.os }}
 
     strategy:
       matrix:
-        python-version: ["3.13", "3.11", "3.9"]
+        os: [macos-latest, ubuntu-latest]
+        python-version: ["3.14", "3.13", "3.11", "3.9"]
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Set up Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
 

--- a/README.md
+++ b/README.md
@@ -12,8 +12,6 @@ utilizes Fourier methods combined with analytic expressions to reduce the
 computation time to scale as N log N, where N is the number of grid points in
 the input linear power spectrum.
 
-NOTE: v3.1.0 and earlier require numpy version < 1.24. This is fixed in v3.1.1 and later, which is available on pip and conda.
-
 Easy installation with pip:
 
 * `pip install fast-pt`

--- a/fastpt/core/FASTPT.py
+++ b/fastpt/core/FASTPT.py
@@ -752,7 +752,7 @@ class FASTPT:
         # Returns relevant correlations (including contraction factors),
         # but WITHOUT bias values and other pre-factors.
         # Uses standard "full initialization" of J terms
-        sig4 = np.trapz(self.k_extrap ** 3 * Ps ** 2, x=np.log(self.k_extrap)) / (2. * pi ** 2)
+        sig4 = np.trapezoid(self.k_extrap ** 3 * Ps ** 2, x=np.log(self.k_extrap)) / (2. * pi ** 2)
         self.cache.set(sig4, "sig4", hash_key, P_hash)
         return sig4
 

--- a/fastpt/core/FASTPT_simple.py
+++ b/fastpt/core/FASTPT_simple.py
@@ -271,8 +271,8 @@ class FASTPT:
 		# Uses standard "full initialization" of J terms
 
 		Power, mat=self.J_k(P,P_window=P_window,C_window=C_window)
-		sig4=np.trapz(self.k_old**2*Power**2,x=self.k_old)/(2.*pi**2)
-		#sig2=np.trapz(self.k_old**2*Power,x=self.k_old)/(2.*pi**2)
+		sig4=np.trapezoid(self.k_old**2*Power**2,x=self.k_old)/(2.*pi**2)
+		#sig2=np.trapezoid(self.k_old**2*Power,x=self.k_old)/(2.*pi**2)
 
 		Pd1d2=2.*(17./21*mat[0,:]+mat[4,:]+4./21*mat[1,:])
 		Pd2d2=2.*(mat[0,:])

--- a/fastpt/utils/matter_power_spt.py
+++ b/fastpt/utils/matter_power_spt.py
@@ -12,7 +12,6 @@ email : jmcewen314@gmail.com
 
 import numpy as np
 from numpy import log, exp, pi
-#from scipy.integrate import trapz
 from scipy.signal import fftconvolve
 from .J_k import J_k
 import sys

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "setuptools.build_meta"
 [project]
 name = "fast-pt"
 dynamic = ["version"]
-requires-python = ">=3.7"
+requires-python = ">=3.9"
 description = "FAST-PT is a code to calculate quantities in cosmological perturbation theory at 1-loop (including, e.g., corrections to the matter power spectrum)."
 readme = "README.md"
 license = { file = "LICENSE" }
@@ -32,9 +32,9 @@ keywords = [
     'Perturbation-Theory'
 ]
 dependencies = [
-    "numpy>=1.17",
-    "scipy>=1.2",
-    "matplotlib>=3.0"
+    "numpy>=2.0",
+    "scipy>=1.13",
+    "matplotlib>=3.9"
 ]
 
 [project.optional-dependencies]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-numpy>=1.17
-scipy>=1.2
+numpy>=2.0
+scipy>=1.12
 matplotlib>=3.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 numpy>=2.0
-scipy>=1.12
-matplotlib>=3.0
+scipy>=1.13
+matplotlib>=3.9


### PR DESCRIPTION
The use of `numpy.trapz`, which is removed in `numpy` v2.4 (it has been deprecated since v2.0).

Replace deprecated np.trapz with np.trapezoid in FASTPT.py and FASTPT_simple.py to maintain compatibility with NumPy 2.0. Update minimum version requirements for numpy (2.0) and scipy (1.12) in requirements.txt.
Remove commented import from matter_power_spt.py.